### PR TITLE
Fixed bad instructions in README.  Should close #1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ the installation instructions for that package (you need Python headers and
 
 To start the proof of concept, run:
 
-    $ sudo iptables -I INPUT -j NFQUEUE --queue-num 0
+    $ sudo iptables -I INPUT -j NFQUEUE --queue-num 1
     $ sudo python concept.py
 
 Note that once you've added the IPTables rule, you will not have any internet
 access, until the firewall starts.  Once you exit the firewall (Control-C), run
 the following command to remove the rule and restore normal operation:
 
-    $ sudo iptables -D INPUT -j NFQUEUE --queue-num 0
+    $ sudo iptables -D INPUT -j NFQUEUE --queue-num 1


### PR DESCRIPTION
Fixed the bad instructions in the README, as mentioned in #1.

**EDIT:** To be clear, the proper command to create the firewall rule is:

```
$ sudo iptables -I INPUT -j NFQUEUE --queue-num 1
```

And to delete:

```
$ sudo iptables -D INPUT -j NFQUEUE --queue-num 1
```
