### PR TITLE
Integrated IP packet object.

### DIFF
--- a/pywall.py
+++ b/pywall.py
@@ -36,25 +36,28 @@ class PyWall(object):
         """Add a rule to a chain."""
         self.chains[chain].append(rule)
 
-    def _apply_chain(self, chain, packet):
+    def _apply_chain(self, chain, nfqueue_packet, pywall_packet):
         """Run the packet through a chain."""
         if chain == 'ACCEPT':
-            packet.accept()
+            nfqueue_packet.accept()
         elif chain == 'DROP':
-            packet.drop()
+            nfqueue_packet.drop()
         else:
             # Match against every rule:
             for rule in self.chains[chain]:
-                result = rule(packet)
+                result = rule(pywall_packet)
                 # If it matches, execute the rule.
                 if result:
-                    return self._apply_chain(result, packet)
+                    return self._apply_chain(result, nfqueue_packet,
+                                             pywall_packet)
             # If no matches, run the default rule.
-            return self._apply_chain(self.default, packet)
+            return self._apply_chain(self.default, nfqueue_packet,
+                                     pywall_packet)
 
     def callback(self, packet):
         """Accept packets from NFQueue."""
-        self._apply_chain(self._start, packet)
+        pywall_packet = IPPacket(packet.get_payload())
+        self._apply_chain(self._start, packet, pywall_packet)
 
     def run(self):
         """Run the PyWall!"""
@@ -77,9 +80,8 @@ class PyWall(object):
 
 def print_ip_packet(packet):
     """Prints out packet information at the IP level."""
-    ip_packet = IPPacket(packet.get_payload())
-    print(unicode(ip_packet))
-    print(unicode(ip_packet.get_payload()))
+    print(unicode(packet))
+    print(unicode(packet.get_payload()))
     return False
 
 


### PR DESCRIPTION
Now that we have wonderful packet objects (courtesy of Jeff), we really don't want to pass around the crappy nfqueue packet objects we get.  Instead, we want to pass around the nice packet objects Jeff made.  So, I changed the core firewall code to pass each rule the IPPacket instead of the nfqueue packet.  Runs pretty much the same as before.
