### PR TITLE
The long awaited support for logging appears.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 *.pyc
 *.pyo
 *.pyd
+*.log

--- a/egress.py
+++ b/egress.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from packets import IPPacket, TCPPacket, to_tuple
 
 import os
+import logging
 
 import netfilterqueue as nfq
 
@@ -39,6 +40,7 @@ class PyWallEgress(object):
         # Parse packet
         ip_packet = IPPacket(packet.get_payload())
         tcp_packet = ip_packet.get_payload()
+        logging.getLogger('pywall.egress').debug(unicode(ip_packet))
 
         # Accept non-TCP packets.
         if type(tcp_packet) is not TCPPacket:

--- a/example.json
+++ b/example.json
@@ -1,17 +1,8 @@
 {
     "default_chain": "ACCEPT",
     "INPUT":[
-        {"name":"PrintRule"},
-        {"name":"TCPRule",
-         "action": "TCP"},
-        {"name": "TrueRule",
-         "action": "ACCEPT"}
-    ],
-    "TCP":[
         {"name":"TCPStateRule",
          "match_if": ["CLOSED"],
-         "action": "DROP"},
-        {"name": "TrueRule",
-         "action": "ACCEPT"}
+         "action": "DROP"}
     ]
 }

--- a/main.py
+++ b/main.py
@@ -2,33 +2,47 @@
 """Main function for PyWall."""
 
 from __future__ import print_function
-import sys
 import multiprocessing as mp
+import logging
+import argparse
 
 import config
 import egress
 import contrack
+from py_log import initialize_logging, log_server
 
 
 def run_pywall(conf, packet_queue, query_pipe, kwargs):
+    logqueue = kwargs.pop('logqueue', mp.Queue())
+    loglevel = kwargs.pop('loglevel', logging.INFO)
+    initialize_logging(loglevel, logqueue)
     cfg = config.PyWallConfig(conf)
     the_wall = cfg.create_pywall(packet_queue, query_pipe)
     the_wall.run(**kwargs)
 
 
-def run_egress(packet_queue):
+def run_egress(packet_queue, loglevel, logqueue):
+    initialize_logging(loglevel, logqueue)
     ct = egress.PyWallEgress(packet_queue)
     ct.run()
 
 
-def main(conf, **kwargs):
+def main(conf, loglevel, filename, **kwargs):
     egress_queue = mp.Queue()
     ingress_queue = mp.Queue()
+    log_queue = mp.Queue()
     query_pywall, query_contrack = mp.Pipe()
+    kwargs['loglevel'] = loglevel
+    kwargs['logqueue'] = log_queue
+    initialize_logging(loglevel, log_queue)
 
     ct = contrack.PyWallConTracker(ingress_queue, egress_queue, query_contrack)
 
-    egress_process = mp.Process(target=run_egress, args=(egress_queue,))
+    log_process = mp.Process(target=log_server, args=(loglevel, log_queue,
+                                                      filename))
+    log_process.start()
+    egress_process = mp.Process(target=run_egress, args=(egress_queue,
+                                                         loglevel, log_queue))
     egress_process.start()
     pywall_process = mp.Process(target=run_pywall, args=(conf, ingress_queue,
                                                          query_pywall, kwargs))
@@ -38,7 +52,13 @@ def main(conf, **kwargs):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print("usage: %s CONFIG-FILE" % (sys.argv[0]), file=sys.stderr)
-        sys.exit(1)
-    main(sys.argv[1])
+
+    parser = argparse.ArgumentParser(description='Build a PyWall')
+    parser.add_argument('config', help='JSON configuration file')
+    parser.add_argument('-l', '--log-level', choices=['DEBUG', 'INFO',
+                                                      'WARNING', 'ERROR',
+                                                      'CRITICAL'],
+                        help='set verbosity of logging', default='INFO')
+    parser.add_argument('-f', '--log-file', help='set log file', default=None)
+    args = parser.parse_args()
+    main(args.config, args.log_level, args.log_file)

--- a/py_log.py
+++ b/py_log.py
@@ -1,0 +1,54 @@
+"""Logging code goes here."""
+
+import logging
+import time
+from logging import StreamHandler, FileHandler
+from logutils.queue import QueueHandler, QueueListener
+
+
+def _get_formatter():
+    return logging.Formatter(fmt='[%(asctime)s][%(levelname)s] %(message)s')
+
+
+def initialize_logging(level, queue):
+
+    formatter = _get_formatter()
+
+    logger = logging.getLogger('pywall')
+    logger.setLevel(level)
+
+    handler = QueueHandler(queue)
+    handler.setLevel(level)
+    handler.setFormatter(formatter)
+
+    logger.addHandler(handler)
+
+
+def log_server(level, queue, filename, mode='w'):
+
+    formatter = _get_formatter()
+    handlers = []
+
+    sh = StreamHandler()
+    sh.setFormatter(formatter)
+    sh.setLevel(level)
+    handlers.append(sh)
+
+    if filename:
+        fh = FileHandler(filename, mode)
+        fh.setFormatter(formatter)
+        fh.setLevel(level)
+        handlers.append(fh)
+
+    listener = QueueListener(queue, *handlers)
+    listener.start()
+
+    # For some reason, queuelisteners run on a separate thread, so now we just
+    # "busy wait" until terminated.
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        listener.stop()

--- a/pywall.py
+++ b/pywall.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from packets import IPPacket, TCPPacket, to_tuple
 
 import os
+import logging
 
 import netfilterqueue as nfq
 
@@ -48,10 +49,12 @@ class PyWall(object):
 
     def _apply_chain(self, chain, nfqueue_packet, pywall_packet):
         """Run the packet through a chain."""
+        l = logging.getLogger('pywall.pywall')
         if chain == 'ACCEPT':
             payload = pywall_packet.get_payload()
             # We don't want to tell the connection tracker that we've accepted a
             # TCP connection until we're sure that we have.
+            l.debug('ACCEPT %s' % unicode(pywall_packet))
             if type(payload) is TCPPacket:
                 tup = to_tuple(pywall_packet)
                 if self.tcp_queue is not None:
@@ -60,6 +63,7 @@ class PyWall(object):
                                         bool(payload.flag_fin)))
             nfqueue_packet.accept()
         elif chain == 'DROP':
+            l.info('DROP %s' % unicode(pywall_packet))
             nfqueue_packet.drop()
         else:
             # Match against every rule:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+logutils==0.3.3
+netaddr==0.7.14
+NetfilterQueue==0.3


### PR DESCRIPTION
This bitch is pretty much ready for merge!  I added logging capabilities, and it all works pretty swimmingly.  The only downside is that logs don't completely come in order -- but the `sort` command does wonders when you happen to have a timestamp as the first part of your log record :).

So, a few points of interest from this:
- There is now a fourth process that just logs.
- I added a new dependency - `logutils`.  This is a backport of new logging classes from Python 3.2 (?) that do exactly what we want -- send logs across a multiprocessing queue, and then receive and handle them.  I figured a new dependency that was a backport wasn't too much of a big deal.
- I added a `requirements.txt` file, so you can pip things better.
- I added an argument parser to `main.py`, so now we can specify a log file and level.

Also, this doesn't break the test runner, so that's a plus.

PS - creative names for logging are also accepted.
